### PR TITLE
Added support for OptixTrace.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,3 +245,7 @@ ModelManifest.xml
 
 # Doxygen ignore
 .doxygen
+
+# Ignore T4 generated files
+Src/ILGPU.Optix/OptixPayload.cs
+Src/ILGPU.Optix/OptixTrace.cs

--- a/Samples/Sample01/Sample01.csproj
+++ b/Samples/Sample01/Sample01.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="1.0.0" />
+    <PackageReference Include="ILGPU" Version="1.2.0-beta1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Sample02/Sample02.csproj
+++ b/Samples/Sample02/Sample02.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="1.0.0" />
+    <PackageReference Include="ILGPU" Version="1.2.0-beta1" />
     <PackageReference Include="StbImageWriteSharp" Version="1.13.5" />
   </ItemGroup>
 

--- a/Samples/Sample03/Sample03.csproj
+++ b/Samples/Sample03/Sample03.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="1.0.0" />
+    <PackageReference Include="ILGPU" Version="1.2.0-beta1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Sample04/Sample04.csproj
+++ b/Samples/Sample04/Sample04.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ILGPU.Algorithms" Version="1.0.0" />
-    <PackageReference Include="ILGPU" Version="1.0.0" />
+    <PackageReference Include="ILGPU.Algorithms" Version="1.2.0-beta1" />
+    <PackageReference Include="ILGPU" Version="1.2.0-beta1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/ILGPU.OptiX/ILGPU.OptiX.csproj
+++ b/Src/ILGPU.OptiX/ILGPU.OptiX.csproj
@@ -34,10 +34,21 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="ILGPU" Version="1.0.0" />
+      <PackageReference Include="ILGPU" Version="1.2.0-beta1" />
+      <PackageReference Include="T4.Build" Version="0.2.4" />
     </ItemGroup>
 
     <ItemGroup>
+      <Compile Update="OptixPayload.cs">
+        <DesignTime>True</DesignTime>
+        <AutoGen>True</AutoGen>
+        <DependentUpon>OptixPayload.tt</DependentUpon>
+      </Compile>
+      <Compile Update="OptixTrace.cs">
+        <DesignTime>True</DesignTime>
+        <AutoGen>True</AutoGen>
+        <DependentUpon>OptixTrace.tt</DependentUpon>
+      </Compile>
       <Compile Update="Resources\ErrorMessages.Designer.cs">
         <DesignTime>True</DesignTime>
         <AutoGen>True</AutoGen>
@@ -50,6 +61,21 @@
         <Generator>ResXFileCodeGenerator</Generator>
         <LastGenOutput>ErrorMessages.Designer.cs</LastGenOutput>
       </EmbeddedResource>
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Update="OptixPayload.tt">
+        <Generator>TextTemplatingFileGenerator</Generator>
+        <LastGenOutput>OptixPayload.cs</LastGenOutput>
+      </None>
+      <None Update="OptixTrace.tt">
+        <Generator>TextTemplatingFileGenerator</Generator>
+        <LastGenOutput>OptixTrace.cs</LastGenOutput>
+      </None>
+    </ItemGroup>
+
+    <ItemGroup>
+      <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
     </ItemGroup>
 
     <Import Project="Properties\ILGPU.CheckStyles.targets" />

--- a/Src/ILGPU.OptiX/OptixPayload.tt
+++ b/Src/ILGPU.OptiX/OptixPayload.tt
@@ -1,0 +1,49 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                     ILGPU OptiX
+//                           Copyright (c) 2022 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: OptixPayload.tt/OptixPayload.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+
+using ILGPU.Runtime.Cuda;
+using System;
+
+namespace ILGPU.OptiX
+{
+    /// <summary>
+    /// Provides the functionality of the optixGetPayload and optixSetPayload built-in
+    /// functions.
+    /// </summary>
+    [CLSCompliant(false)]
+    public static class OptixPayload
+    {
+<# for (int payloadIdx = 0; payloadIdx <= 8; payloadIdx++) { #>
+        public static uint Payload<#= payloadIdx #>
+        {
+            get
+            {
+                CudaAsm.Emit(
+                    "call (%0), _optix_get_payload_<#= payloadIdx #>, ();",
+                    out uint x);
+                return x;
+            }
+            set
+            {
+                CudaAsm.Emit("call _optix_set_payload_<#= payloadIdx #>, (%0);", value);
+            }
+        }
+
+<# } #>
+    }
+}

--- a/Src/ILGPU.OptiX/OptixRayFlags.cs
+++ b/Src/ILGPU.OptiX/OptixRayFlags.cs
@@ -1,0 +1,95 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                     ILGPU OptiX
+//                           Copyright (c) 2022 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: OptixRayFlags.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+using System;
+
+#pragma warning disable CA1008 // Enums should have zero value
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
+
+// disable: max_line_length
+
+namespace ILGPU.OptiX
+{
+    [Flags]
+    public enum OptixRayFlags
+    {
+        /// <summary>
+        /// No change from the behavior configured for the individual AS.
+        /// </summary>
+        OPTIX_RAY_FLAG_NONE = 0,
+
+        /// <summary>
+        /// Disables anyhit programs for the ray.
+        /// Overrides OPTIX_INSTANCE_FLAG_ENFORCE_ANYHIT.
+        /// This flag is mutually exclusive with OPTIX_RAY_FLAG_ENFORCE_ANYHIT,
+        /// OPTIX_RAY_FLAG_CULL_DISABLED_ANYHIT, OPTIX_RAY_FLAG_CULL_ENFORCED_ANYHIT.
+        /// </summary>
+        OPTIX_RAY_FLAG_DISABLE_ANYHIT = 1 << 0,
+
+        /// <summary>
+        /// Forces anyhit program execution for the ray.
+        /// Overrides OPTIX_GEOMETRY_FLAG_DISABLE_ANYHIT as well as OPTIX_INSTANCE_FLAG_DISABLE_ANYHIT.
+        /// This flag is mutually exclusive with OPTIX_RAY_FLAG_DISABLE_ANYHIT,
+        /// OPTIX_RAY_FLAG_CULL_DISABLED_ANYHIT, OPTIX_RAY_FLAG_CULL_ENFORCED_ANYHIT.
+        /// </summary>
+        OPTIX_RAY_FLAG_ENFORCE_ANYHIT = 1 << 1,
+
+        /// <summary>
+        /// Terminates the ray after the first hit and executes
+        /// the closesthit program of that hit.
+        /// </summary>
+        OPTIX_RAY_FLAG_TERMINATE_ON_FIRST_HIT = 1 << 2,
+
+        /// <summary>
+        /// Disables closesthit programs for the ray, but still executes miss program in case of a miss.
+        /// </summary>
+        OPTIX_RAY_FLAG_DISABLE_CLOSESTHIT = 1 << 3,
+
+        /// <summary>
+        /// Do not intersect triangle back faces
+        /// (respects a possible face change due to instance flag
+        /// OPTIX_INSTANCE_FLAG_FLIP_TRIANGLE_FACING).
+        /// This flag is mutually exclusive with OPTIX_RAY_FLAG_CULL_FRONT_FACING_TRIANGLES.
+        /// </summary>
+        OPTIX_RAY_FLAG_CULL_BACK_FACING_TRIANGLES = 1 << 4,
+
+        /// <summary>
+        /// Do not intersect triangle front faces
+        /// (respects a possible face change due to instance flag
+        /// OPTIX_INSTANCE_FLAG_FLIP_TRIANGLE_FACING).
+        /// This flag is mutually exclusive with OPTIX_RAY_FLAG_CULL_BACK_FACING_TRIANGLES.
+        /// </summary>
+        OPTIX_RAY_FLAG_CULL_FRONT_FACING_TRIANGLES = 1 << 5,
+
+        /// <summary>
+        /// Do not intersect geometry which disables anyhit programs
+        /// (due to setting geometry flag OPTIX_GEOMETRY_FLAG_DISABLE_ANYHIT or
+        /// instance flag OPTIX_INSTANCE_FLAG_DISABLE_ANYHIT).
+        /// This flag is mutually exclusive with OPTIX_RAY_FLAG_CULL_ENFORCED_ANYHIT,
+        /// OPTIX_RAY_FLAG_ENFORCE_ANYHIT, OPTIX_RAY_FLAG_DISABLE_ANYHIT.
+        /// </summary>
+        OPTIX_RAY_FLAG_CULL_DISABLED_ANYHIT = 1 << 6,
+
+        /// <summary>
+        /// Do not intersect geometry which have an enabled anyhit program
+        /// (due to not setting geometry flag OPTIX_GEOMETRY_FLAG_DISABLE_ANYHIT or
+        /// setting instance flag OPTIX_INSTANCE_FLAG_ENFORCE_ANYHIT).
+        /// This flag is mutually exclusive with OPTIX_RAY_FLAG_CULL_DISABLED_ANYHIT,
+        /// OPTIX_RAY_FLAG_ENFORCE_ANYHIT, OPTIX_RAY_FLAG_DISABLE_ANYHIT.
+        /// </summary>
+        OPTIX_RAY_FLAG_CULL_ENFORCED_ANYHIT = 1 << 7
+    }
+}
+
+#pragma warning restore CA1008 // Enums should have zero value
+#pragma warning restore CA1707 // Identifiers should not contain underscores
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix

--- a/Src/ILGPU.OptiX/OptixTrace.tt
+++ b/Src/ILGPU.OptiX/OptixTrace.tt
@@ -1,0 +1,112 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                     ILGPU OptiX
+//                           Copyright (c) 2022 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: OptixTrace.tt/OptixTrace.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+
+using ILGPU.Runtime.Cuda;
+using System;
+
+namespace ILGPU.OptiX
+{
+    /// <summary>
+    /// Provides the functionality of the optixTrace built-in function.
+    /// </summary>
+    [CLSCompliant(false)]
+    public static class OptixTrace
+    {
+<#
+    for (int paramIdx = 0; paramIdx <= 8; paramIdx++) {
+        string callInstruction = "call";
+        if (paramIdx > 0)
+        {
+            callInstruction += " (";
+            callInstruction += string.Join(
+                ", ",
+                Enumerable.Range(0, paramIdx).Select(x => $"%{x}"));
+            callInstruction += ")";
+        }
+        callInstruction += $" _optix_trace_{paramIdx}, (";
+        callInstruction += string.Join(
+            ", ",
+            Enumerable.Range(paramIdx, 15 + paramIdx).Select(x => $"%{x}"));
+        callInstruction += ");";
+#>
+        public static void Trace(
+            IntPtr traversableHandle
+            , (float X, float Y, float Z) rayOrigin
+            , (float X, float Y, float Z) rayDirection
+            , float tmin
+            , float tmax
+            , float rayTime
+            , uint visibilityMask
+            , OptixRayFlags rayFlags
+            , uint SBToffset
+            , uint SBTstride
+            , uint missSBTIndex
+<#      for (int i = 0; i < paramIdx; i++) { #>
+            , ref uint p<#= i #>
+<#      } #>
+            )
+        {
+            Input<IntPtr> _traversableHandle = traversableHandle;
+            Input<float> _ox = rayOrigin.X;
+            Input<float> _oy = rayOrigin.Y;
+            Input<float> _oz = rayOrigin.Z;
+            Input<float> _dx = rayDirection.X;
+            Input<float> _dy = rayDirection.Y;
+            Input<float> _dz = rayDirection.Z;
+            Input<float> _tmin = tmin;
+            Input<float> _tmax = tmax;
+            Input<float> _rayTime = rayTime;
+            Input<uint> _visibilityMask = visibilityMask;
+            Input<OptixRayFlags> _rayFlags = rayFlags;
+            Input<uint> _SBToffset = SBToffset;
+            Input<uint> _SBTstride = SBTstride;
+            Input<uint> _missSBTIndex = missSBTIndex;
+<#      for (int i = 0; i < paramIdx; i++) { #>
+            Ref<uint> _p<#= i #> = p<#= i #>;
+<#      } #>
+
+            CudaAsm.EmitRef(
+                "<#= callInstruction #>"
+                , ref _traversableHandle
+                , ref _ox
+                , ref _oy
+                , ref _oz
+                , ref _dx
+                , ref _dy
+                , ref _dz
+                , ref _tmin
+                , ref _tmax
+                , ref _rayTime
+                , ref _visibilityMask
+                , ref _rayFlags
+                , ref _SBToffset
+                , ref _SBTstride
+                , ref _missSBTIndex
+<#      for (int i = 0; i < paramIdx; i++) { #>
+                , ref _p<#= i #>
+<#      } #>
+                );
+
+<#      for (int i = 0; i < paramIdx; i++) { #>
+            p<#= i #> = _p<#= i #>.Value;
+<#      } #>
+        }
+
+<# } #>
+    }
+}


### PR DESCRIPTION
Fixes #2.

We currently target ILGPU OptiX v7.2. This only allows up to 8 payloads.